### PR TITLE
make sure user exist in both v3 api and v5 api

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -17,6 +17,8 @@ module.exports = {
   TC_API: process.env.TC_API || 'https://api.topcoder-dev.com/v5',
   ORG_ID: process.env.ORG_ID || '36ed815b-3da1-49f1-a043-aaed0a4e81ad',
 
+  TOPCODER_USERS_API: process.env.TOPCODER_USERS_API || 'https://api.topcoder-dev.com/v3/users',
+
   DATABASE_URL: process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/postgres',
   DB_SCHEMA_NAME: process.env.DB_SCHEMA_NAME || 'bookings',
   PROJECT_API_URL: process.env.PROJECT_API_URL || 'https://api.topcoder-dev.com',

--- a/package-lock.json
+++ b/package-lock.json
@@ -908,6 +908,65 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "auth0-js": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.14.0.tgz",
+      "integrity": "sha512-40gIBUejmYAYse06ck6sxdNO0KU0pX+KDIQsWAkcyFtI0HU6dY5aeHxZfVYkYjtbArKr5s13LuZFdKrUiGyCqQ==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "idtoken-verifier": "^2.0.3",
+        "js-cookie": "^2.2.0",
+        "qs": "^6.7.0",
+        "superagent": "^5.3.1",
+        "url-join": "^4.0.1",
+        "winchan": "^0.2.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "superagent": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.3.1.tgz",
+          "integrity": "sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==",
+          "requires": {
+            "component-emitter": "^1.3.0",
+            "cookiejar": "^2.1.2",
+            "debug": "^4.1.1",
+            "fast-safe-stringify": "^2.0.7",
+            "form-data": "^3.0.0",
+            "formidable": "^1.2.2",
+            "methods": "^1.1.2",
+            "mime": "^2.4.6",
+            "qs": "^6.9.4",
+            "readable-stream": "^3.6.0",
+            "semver": "^7.3.2"
+          },
+          "dependencies": {
+            "qs": {
+              "version": "6.9.4",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+              "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+            }
+          }
+        }
+      }
+    },
     "available-typed-arrays": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
@@ -1516,6 +1575,11 @@
         }
       }
     },
+    "crypto-js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -1811,6 +1875,11 @@
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escape-goat": {
       "version": "2.1.1",
@@ -2793,6 +2862,26 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "idtoken-verifier": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/idtoken-verifier/-/idtoken-verifier-2.1.0.tgz",
+      "integrity": "sha512-X0423UM4Rc5bFb39Ai0YHr35rcexlu4oakKdYzSGZxtoPy84P86hhAbzlpgbgomcLOFRgzgKRvhY7YjO5g8OPA==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "crypto-js": "^3.2.1",
+        "es6-promise": "^4.2.8",
+        "jsbn": "^1.1.0",
+        "unfetch": "^4.1.0",
+        "url-join": "^4.0.1"
+      },
+      "dependencies": {
+        "jsbn": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+          "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+        }
+      }
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -3355,6 +3444,11 @@
         "@hapi/topo": "^5.0.0"
       }
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3548,6 +3642,31 @@
       "dev": true,
       "requires": {
         "package-json": "^6.3.0"
+      }
+    },
+    "le_node": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/le_node/-/le_node-1.8.0.tgz",
+      "integrity": "sha512-NXzjxBskZ4QawTNwlGdRG05jYU0LhV2nxxmP3x7sRMHyROV0jPdyyikO9at+uYrWX3VFt0Y/am11oKITedx0iw==",
+      "requires": {
+        "babel-runtime": "6.6.1",
+        "codependency": "0.1.4",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.11",
+        "reconnect-core": "1.3.0",
+        "semver": "5.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "semver": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU="
+        }
       }
     },
     "levn": {
@@ -5653,6 +5772,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "stream-consume": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
+      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg=="
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -5817,17 +5941,37 @@
       }
     },
     "tc-core-library-js": {
-      "version": "github:appirio-tech/tc-core-library-js#081138e1f5eae76171abeff34b8f326b3fb2b504",
-      "from": "github:appirio-tech/tc-core-library-js#v2.6.5",
+      "version": "github:appirio-tech/tc-core-library-js#d16413db30b1eed21c0cf426e185bedb2329ddab",
+      "from": "github:appirio-tech/tc-core-library-js#v2.6",
       "requires": {
-        "axios": "^0.19.0",
+        "auth0-js": "^9.4.2",
+        "axios": "^0.12.0",
         "bunyan": "^1.8.12",
-        "jsonwebtoken": "^8.5.1",
-        "jwks-rsa": "^1.6.0",
-        "lodash": "^4.17.15",
+        "jsonwebtoken": "^8.3.0",
+        "jwks-rsa": "^1.3.0",
+        "le_node": "^1.3.1",
+        "lodash": "^4.17.10",
         "millisecond": "^0.1.2",
-        "r7insight_node": "^1.8.4",
         "request": "^2.88.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.12.0.tgz",
+          "integrity": "sha1-uQewIhzDTsHJ+sGOx/B935V4W6Q=",
+          "requires": {
+            "follow-redirects": "0.0.7"
+          }
+        },
+        "follow-redirects": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
+          "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
+          "requires": {
+            "debug": "^2.2.0",
+            "stream-consume": "^0.1.0"
+          }
+        }
       }
     },
     "term-size": {
@@ -6008,6 +6152,11 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
       "integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw=="
     },
+    "unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -6124,6 +6273,11 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "url-parse-lax": {
       "version": "3.0.0",
@@ -6274,6 +6428,11 @@
       "requires": {
         "string-width": "^4.0.0"
       }
+    },
+    "winchan": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/winchan/-/winchan-0.2.2.tgz",
+      "integrity": "sha512-pvN+IFAbRP74n/6mc6phNyCH8oVkzXsto4KCHPJ2AScniAnA1AmeLI03I2BzjePpaClGSI4GUMowzsD3qz5PRQ=="
     },
     "winston": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rewire": "^5.0.0",
     "sequelize": "^6.3.5",
     "superagent": "^6.1.0",
-    "tc-core-library-js": "github:appirio-tech/tc-core-library-js#v2.6.5",
+    "tc-core-library-js": "github:appirio-tech/tc-core-library-js#v2.6",
     "util": "^0.12.3",
     "uuid": "^8.3.1",
     "winston": "^3.3.3"


### PR DESCRIPTION
## Note
I downgrade the version of the `tc-core-library-js` library from v2.6.5 to v2.6.

Just like u-bhan-bulk-processor(refer https://github.com/topcoder-platform/u-bahn-bulk-processor/blob/develop/src/common/helper.js#L18-L19), we need two m2m auth clients, one for ubhan resources, the other for ordinary topcoder resources(like /v3/users). The version 2.6.5 of tc-core-library-js seems cache tokens across clients, but what we would expected is each client caches its own token.

The version 2.6 of tc-core-library-js does not have this issue, so I degrade the library to v2.6.