### PR TITLE
fix calculation of last week day

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1594,6 +1594,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
+      "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "aws-sdk": "^2.787.0",
     "config": "^3.3.2",
     "cors": "^2.8.5",
+    "date-fns": "^2.16.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-interceptor": "^1.2.0",

--- a/src/services/TeamService.js
+++ b/src/services/TeamService.js
@@ -4,6 +4,7 @@
 
 const _ = require('lodash')
 const Joi = require('joi')
+const dateFNS = require('date-fns')
 const helper = require('../common/helper')
 const logger = require('../common/logger')
 const JobService = require('./JobService')
@@ -65,13 +66,9 @@ async function getTeamDetail (currentUser, projects, isSearch = true) {
 
   // Get first week day and last week day
   const curr = new Date()
-  curr.setHours(0, 0, 0, 0)
-  const first = curr.getDate() - curr.getDay()
-  const last = first + 6
+  const firstDay = dateFNS.startOfWeek(curr)
+  const lastDay = dateFNS.endOfWeek(curr)
 
-  const firstDay = new Date(curr.setDate(first))
-  const lastDay = new Date(curr.setDate(last))
-  lastDay.setHours(23, 59, 59, 59) // the end of the day
   logger.debug({ component: 'TeamService', context: 'getTeamDetail', message: `week started: ${firstDay}, week ended: ${lastDay}` })
 
   const result = []


### PR DESCRIPTION
## Original Behavior:

``` bash
[2020-12-02T16:15:41.474Z] TeamService getTeamDetail DEBUG : week started: Sun Nov 29 2020 00:00:00 GMT+0000 (Coordinated Universal Time), week ended: Thu Nov 05 2020 23:59:59 GMT+0000 (Coordinated Universal Time)
```
Notice the week ended is _Nov 05_
## After Fix
``` bash
[2020-12-02T16:16:36.615Z] TeamService getTeamDetail DEBUG : week started: Sun Nov 29 2020 00:00:00 GMT+0000 (Coordinated Universal Time), week ended: Sat Dec 05 2020 23:59:59 GMT+0000 (Coordinated Universal Time)
```
Notice the week ended is _Dec 05_
