### PR TITLE
add input checks of jobId and userId to JobCandidate and ResouceBooking services

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -499,6 +499,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: Internal Server Error
           content:
@@ -894,6 +900,12 @@ paths:
                 $ref: '#/components/schemas/Error'
         '403':
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Not Found
           content:
             application/json:
               schema:

--- a/src/services/JobCandidateService.js
+++ b/src/services/JobCandidateService.js
@@ -54,6 +54,9 @@ getJobCandidate.schema = Joi.object().keys({
  * @returns {Object} the created jobCandidate
  */
 async function createJobCandidate (currentUser, jobCandidate) {
+  await helper.ensureJobById(jobCandidate.jobId) // ensure job exists
+  await helper.ensureUserById(jobCandidate.userId) // ensure user exists
+
   jobCandidate.id = uuid()
   jobCandidate.createdAt = new Date()
   jobCandidate.createdBy = await helper.getUserId(currentUser.userId)
@@ -127,6 +130,8 @@ partiallyUpdateJobCandidate.schema = Joi.object().keys({
  * @returns {Object} the updated jobCandidate
  */
 async function fullyUpdateJobCandidate (currentUser, id, data) {
+  await helper.ensureJobById(data.jobId) // ensure job exists
+  await helper.ensureUserById(data.userId) // ensure user exists
   return updateJobCandidate(currentUser, id, data)
 }
 

--- a/src/services/ResourceBookingService.js
+++ b/src/services/ResourceBookingService.js
@@ -73,6 +73,11 @@ getResourceBooking.schema = Joi.object().keys({
  * @returns {Object} the created resourceBooking
  */
 async function createResourceBooking (currentUser, resourceBooking) {
+  if (resourceBooking.jobId) {
+    await helper.ensureJobById(resourceBooking.jobId) // ensure job exists
+  }
+  await helper.ensureUserById(resourceBooking.userId) // ensure user exists
+
   if (!currentUser.isBookingManager && !currentUser.isMachine) {
     const connect = await helper.isConnectMember(resourceBooking.projectId, currentUser.jwtToken)
     if (!connect) {
@@ -186,6 +191,10 @@ partiallyUpdateResourceBooking.schema = Joi.object().keys({
  * @returns {Object} the updated resourceBooking
  */
 async function fullyUpdateResourceBooking (currentUser, id, data) {
+  if (data.jobId) {
+    await helper.ensureJobById(data.jobId) // ensure job exists
+  }
+  await helper.ensureUserById(data.userId) // ensure user exists
   return updateResourceBooking(currentUser, id, data)
 }
 


### PR DESCRIPTION
## Changes
- update source code
- in the swagger document update endpoints `POST(PUT) /jobCandidates` and `POST(PUT) /resourceBookings` to include 404 responses.
## Verification
Execute the following requests with different jobIds or userIds for validating:

`Jobs > create job candidate with booking manager`
`Jobs > put job candidate with booking manager`
`Job Candidates > create resource booking with booking manager`
`Job Candidates > put resource booking with booking manager`

## Notes
`PATCH /jobCandidates` and `PATCH /resourceBooking` remain unchanged since these endpoints do not related to jobId or userId. 