### PR TITLE
allow booking manager to access all teams

### DIFF
--- a/docs/Topcoder-bookings-api.postman_collection.json
+++ b/docs/Topcoder-bookings-api.postman_collection.json
@@ -4126,6 +4126,54 @@
 					"response": []
 				},
 				{
+					"name": "GET /taas-teams with booking manager",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token_bookingManager}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{URL}}/taas-teams?perPage=10&page=1&name=*taas*&sortBy=lastActivityAt&sortOrder=desc",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"taas-teams"
+							],
+							"query": [
+								{
+									"key": "perPage",
+									"value": "10"
+								},
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "name",
+									"value": "*taas*",
+									"description": "case-insensitive; support wildcard match"
+								},
+								{
+									"key": "sortBy",
+									"value": "lastActivityAt",
+									"description": "allows: createdAt, updatedAt, lastActivityAt, id, status, name, type, best match"
+								},
+								{
+									"key": "sortOrder",
+									"value": "desc",
+									"description": "allows: asc, desc"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "GET /taas-teams with m2m read",
 					"request": {
 						"method": "GET",
@@ -4156,6 +4204,36 @@
 							{
 								"key": "Authorization",
 								"value": "Bearer {{token_connectUser}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{URL}}/taas-teams/:projectId",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"taas-teams",
+								":projectId"
+							],
+							"variable": [
+								{
+									"key": "projectId",
+									"value": "16705"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET /taas-teams/:id with booking manager",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token_bookingManager}}",
 								"type": "text"
 							}
 						],
@@ -4216,6 +4294,42 @@
 							{
 								"key": "Authorization",
 								"value": "Bearer {{token_connectUser}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{URL}}/taas-teams/:projectId/jobs/:jobId",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"taas-teams",
+								":projectId",
+								"jobs",
+								":jobId"
+							],
+							"variable": [
+								{
+									"key": "projectId",
+									"value": "16705"
+								},
+								{
+									"key": "jobId",
+									"value": "948a25a6-086f-4a96-aad5-9ccd2d3e87b2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET /taas-teams/:id/jobs/:jobId with booking manager",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token_bookingManager}}",
 								"type": "text"
 							}
 						],

--- a/src/services/TeamService.js
+++ b/src/services/TeamService.js
@@ -41,8 +41,8 @@ async function _getJobsByProjectIds (projectIds) {
  * @returns {Object} the search result, contain total/page/perPage and result array
  */
 async function searchTeams (currentUser, criteria) {
-  if (currentUser.isMachine) {
-    const m2mToken = await helper.getM2Mtoken()
+  if (currentUser.isBookingManager || currentUser.isMachine) {
+    const m2mToken = await helper.getTopcoderM2MToken()
     currentUser.jwtToken = `Bearer ${m2mToken}`
   }
   const sort = `${criteria.sortBy} ${criteria.sortOrder}`
@@ -197,8 +197,8 @@ async function getTeamDetail (currentUser, projects, isSearch = true) {
  * @returns {Object} the team
  */
 async function getTeam (currentUser, id) {
-  if (currentUser.isMachine) {
-    const m2mToken = await helper.getM2Mtoken()
+  if (currentUser.isBookingManager || currentUser.isMachine) {
+    const m2mToken = await helper.getTopcoderM2MToken()
     currentUser.jwtToken = `Bearer ${m2mToken}`
   }
   // Get users from /v5/projects
@@ -253,8 +253,8 @@ getTeam.schema = Joi.object().keys({
  * @returns the team job
  */
 async function getTeamJob (currentUser, id, jobId) {
-  if (currentUser.isMachine) {
-    const m2mToken = await helper.getM2Mtoken()
+  if (currentUser.isBookingManager || currentUser.isMachine) {
+    const m2mToken = await helper.getTopcoderM2MToken()
     currentUser.jwtToken = `Bearer ${m2mToken}`
   }
   // Get jobs from taas api
@@ -286,13 +286,7 @@ async function getTeamJob (currentUser, id, jobId) {
     const userHandles = _.map(candidates, 'handle')
     if (userHandles && userHandles.length > 0) {
       // Get user photo from /v5/members
-      let members
-      if (currentUser.isMachine) {
-        const m2mToken = await helper.getTopcoderM2MToken()
-        members = await helper.getMembers(`Bearer ${m2mToken}`, userHandles)
-      } else {
-        members = await helper.getMembers(currentUser.jwtToken, userHandles)
-      }
+      const members = await helper.getMembers(currentUser.jwtToken, userHandles)
 
       for (const item of candidates) {
         item.resumeLink = null

--- a/src/services/TeamService.js
+++ b/src/services/TeamService.js
@@ -42,7 +42,7 @@ async function _getJobsByProjectIds (projectIds) {
  */
 async function searchTeams (currentUser, criteria) {
   if (currentUser.isBookingManager || currentUser.isMachine) {
-    const m2mToken = await helper.getTopcoderM2MToken()
+    const m2mToken = await helper.getM2Mtoken()
     currentUser.jwtToken = `Bearer ${m2mToken}`
   }
   const sort = `${criteria.sortBy} ${criteria.sortOrder}`
@@ -198,7 +198,7 @@ async function getTeamDetail (currentUser, projects, isSearch = true) {
  */
 async function getTeam (currentUser, id) {
   if (currentUser.isBookingManager || currentUser.isMachine) {
-    const m2mToken = await helper.getTopcoderM2MToken()
+    const m2mToken = await helper.getM2Mtoken()
     currentUser.jwtToken = `Bearer ${m2mToken}`
   }
   // Get users from /v5/projects
@@ -254,7 +254,7 @@ getTeam.schema = Joi.object().keys({
  */
 async function getTeamJob (currentUser, id, jobId) {
   if (currentUser.isBookingManager || currentUser.isMachine) {
-    const m2mToken = await helper.getTopcoderM2MToken()
+    const m2mToken = await helper.getM2Mtoken()
     currentUser.jwtToken = `Bearer ${m2mToken}`
   }
   // Get jobs from taas api


### PR DESCRIPTION
New requests added to Postman collection for verification:
- `Taas Teams > GET /taas-teams with booking manager`
- `Taas Teams > GET /taas-teams/:id with booking manager`
- `Taas Teams > GET /taas-teams/:id/jobs/:jobId with m2m read`