### PR TITLE
TeamService: use m2m token for internal api calls

### DIFF
--- a/src/services/JobService.js
+++ b/src/services/JobService.js
@@ -54,10 +54,9 @@ async function _getJobCandidates (jobId) {
  * @returns {undefined}
  */
 async function _validateSkills (skills) {
-  const m2mToken = await helper.getM2Mtoken()
   const responses = await Promise.all(
     skills.map(
-      skill => helper.getSkillById(`Bearer ${m2mToken}`, skill)
+      skill => helper.getSkillById(skill)
         .then(() => {
           return { found: true }
         })


### PR DESCRIPTION
## Changelog
- All internal api calls inside `TeamService`(except `helper.getProjects()` and `helper.getProjectById()`) are directly using m2m token instead of delegating the token from user who make the request.
   This also affects `JobService`, so the `_validateSkills()` function in `JobService` is slightly modified to catch up the changes.
- `TeamService.getTeamJob()` would check if user can access the team by invoking `helper.getProjectId()` before continue to process the request.