### PR TITLE
turn a job into in-review status after it has a candidate

### DIFF
--- a/src/eventHandlers/JobCandidateEventHandler.js
+++ b/src/eventHandlers/JobCandidateEventHandler.js
@@ -1,0 +1,51 @@
+/*
+ * Handle events for JobCandidate.
+ */
+
+const models = require('../models')
+const logger = require('../common/logger')
+const helper = require('../common/helper')
+const JobService = require('../services/JobService')
+
+/**
+ * Once we create at least one JobCandidate for a Job, the Job status should be changed to in-review.
+ *
+ * @param {Object} payload the event payload
+ * @returns {undefined}
+ */
+async function inReviewJob (payload) {
+  const job = await models.Job.findById(payload.value.jobId)
+  if (job.status === 'in-review') {
+    logger.debug({
+      component: 'JobCandidateEventHandler',
+      context: 'inReviewJob',
+      message: `id: ${job.id} job is already in in-review status`
+    })
+    return
+  }
+  await JobService.partiallyUpdateJob(
+    helper.getAuditM2Muser(),
+    job.id,
+    { status: 'in-review' }
+  ).then(result => {
+    logger.info({
+      component: 'JobCandidateEventHandler',
+      context: 'inReviewJob',
+      message: `id: ${result.id} job got in-review status.`
+    })
+  })
+}
+
+/**
+ * Process job candidate create event.
+ *
+ * @param {Object} payload the event payload
+ * @returns {undefined}
+ */
+async function processCreate (payload) {
+  await inReviewJob(payload)
+}
+
+module.exports = {
+  processCreate
+}

--- a/src/eventHandlers/index.js
+++ b/src/eventHandlers/index.js
@@ -5,11 +5,13 @@
 const config = require('config')
 const eventDispatcher = require('../common/eventDispatcher')
 const JobEventHandler = require('./JobEventHandler')
+const JobCandidateEventHandler = require('./JobCandidateEventHandler')
 const ResourceBookingEventHandler = require('./ResourceBookingEventHandler')
 const logger = require('../common/logger')
 
 const TopicOperationMapping = {
   [config.TAAS_JOB_UPDATE_TOPIC]: JobEventHandler.processUpdate,
+  [config.TAAS_JOB_CANDIDATE_CREATE_TOPIC]: JobCandidateEventHandler.processCreate,
   [config.TAAS_RESOURCE_BOOKING_UPDATE_TOPIC]: ResourceBookingEventHandler.processUpdate
 }
 


### PR DESCRIPTION
- add a new event handler for the `taas.jobcandidate.create` topic
- turn a job into in-review status after it has a candidate
- do not repeatedly update the job status if it is already in in-review status