### PR TITLE
return resume instead of resumeLink in `TeamService.getTeamJob`

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2310,12 +2310,12 @@ components:
               id:
                 type: string
                 format: uuid
-                description: "The job cadidate id."
+                description: "The job candidate id."
               userId:
                 type: string
                 format: uuid
                 description: "User id."
-              resumeLink: 
+              resume: 
                 type: string
                 format: url
                 description: 'The link for the resume that can be downloaded'

--- a/src/services/TeamService.js
+++ b/src/services/TeamService.js
@@ -267,11 +267,11 @@ async function getTeamJob (currentUser, id, jobId) {
       const members = await helper.getMembers(userHandles)
 
       for (const item of candidates) {
-        item.resumeLink = null
         const candidate = _.find(job.candidates, { userId: item.id })
         // TODO this logic should be vice-verse, we should loop trough candidates and populate users data if found,
         //      not loop through users and populate candidates data if found
         if (candidate) {
+          item.resume = candidate.resume
           item.status = candidate.status
           // return User id as `userId` and JobCandidate id as `id`
           item.userId = item.id


### PR DESCRIPTION
- for `GET /taas-teams/:id/jobs/:jobId` return `resume` properties from candidates
- swagger updated accordingly
- fix a small typo in swagger