### PR TITLE
[1.5] allow setting status during Job/JobCandidate/ResourceBooking creation

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1734,6 +1734,11 @@ components:
           example: "Dummy title"
           description: "The title."
           maxLength: 64
+        status:
+          type: string
+          enum: ['sourcing', 'in-review', 'assigned', 'closed', 'cancelled']
+          description: "The job status."
+          default: sourcing
         startDate:
           type: string
           format: date-time
@@ -1829,6 +1834,11 @@ components:
           format: uuid
           example: "a55fe1bc-1754-45fa-9adc-cf3d6d7c377a"
           description: "The user id."
+        status:
+          type: string
+          enum: ['open', 'selected', 'shortlist', 'rejected', 'cancelled']
+          description: "The job candidate status."
+          default: open
         externalId:
           type: string
           example: "1212"
@@ -1983,6 +1993,11 @@ components:
           type: string
           format: uuid
           description: "The job id."
+        status:
+          type: string
+          enum: ['sourcing', 'in-review', 'assigned', 'closed', 'cancelled']
+          description: "The job status."
+          default: sourcing
         startDate:
           type: string
           format: date-time

--- a/src/eventHandlers/ResourceBookingEventHandler.js
+++ b/src/eventHandlers/ResourceBookingEventHandler.js
@@ -3,6 +3,7 @@
  */
 
 const { Op } = require('sequelize')
+const _ = require('lodash')
 const models = require('../models')
 const logger = require('../common/logger')
 const helper = require('../common/helper')
@@ -18,7 +19,7 @@ const JobCandidateService = require('../services/JobCandidateService')
  * @returns {undefined}
  */
 async function selectJobCandidate (payload) {
-  if (payload.value.status === payload.options.oldValue.status) {
+  if (_.get(payload, 'options.oldValue') && payload.value.status === payload.options.oldValue.status) {
     logger.debug({
       component: 'ResourceBookingEventHandler',
       context: 'selectJobCandidate',
@@ -73,7 +74,7 @@ async function selectJobCandidate (payload) {
  * @returns {undefined}
  */
 async function assignJob (payload) {
-  if (payload.value.status === payload.options.oldValue.status) {
+  if (_.get(payload, 'options.oldValue') && payload.value.status === payload.options.oldValue.status) {
     logger.debug({
       component: 'ResourceBookingEventHandler',
       context: 'assignJob',
@@ -126,6 +127,17 @@ async function assignJob (payload) {
 }
 
 /**
+ * Process resource booking create event.
+ *
+ * @param {Object} payload the event payload
+ * @returns {undefined}
+ */
+async function processCreate (payload) {
+  await selectJobCandidate(payload)
+  await assignJob(payload)
+}
+
+/**
  * Process resource booking update event.
  *
  * @param {Object} payload the event payload
@@ -137,5 +149,6 @@ async function processUpdate (payload) {
 }
 
 module.exports = {
+  processCreate,
   processUpdate
 }

--- a/src/eventHandlers/index.js
+++ b/src/eventHandlers/index.js
@@ -12,6 +12,7 @@ const logger = require('../common/logger')
 const TopicOperationMapping = {
   [config.TAAS_JOB_UPDATE_TOPIC]: JobEventHandler.processUpdate,
   [config.TAAS_JOB_CANDIDATE_CREATE_TOPIC]: JobCandidateEventHandler.processCreate,
+  [config.TAAS_RESOURCE_BOOKING_CREATE_TOPIC]: ResourceBookingEventHandler.processCreate,
   [config.TAAS_RESOURCE_BOOKING_UPDATE_TOPIC]: ResourceBookingEventHandler.processUpdate
 }
 

--- a/src/services/JobCandidateService.js
+++ b/src/services/JobCandidateService.js
@@ -92,7 +92,6 @@ async function createJobCandidate (currentUser, jobCandidate) {
   jobCandidate.id = uuid()
   jobCandidate.createdAt = new Date()
   jobCandidate.createdBy = await helper.getUserId(currentUser.userId)
-  jobCandidate.status = 'open'
 
   const created = await JobCandidate.create(jobCandidate)
   await helper.postEvent(config.TAAS_JOB_CANDIDATE_CREATE_TOPIC, jobCandidate)
@@ -102,6 +101,7 @@ async function createJobCandidate (currentUser, jobCandidate) {
 createJobCandidate.schema = Joi.object().keys({
   currentUser: Joi.object().required(),
   jobCandidate: Joi.object().keys({
+    status: Joi.jobCandidateStatus().default('open'),
     jobId: Joi.string().uuid().required(),
     userId: Joi.string().uuid().required(),
     externalId: Joi.string(),

--- a/src/services/JobService.js
+++ b/src/services/JobService.js
@@ -152,7 +152,6 @@ async function createJob (currentUser, job) {
   job.id = uuid()
   job.createdAt = new Date()
   job.createdBy = await helper.getUserId(currentUser.userId)
-  job.status = 'sourcing'
 
   const created = await Job.create(job)
   await helper.postEvent(config.TAAS_JOB_CREATE_TOPIC, job)
@@ -162,6 +161,7 @@ async function createJob (currentUser, job) {
 createJob.schema = Joi.object().keys({
   currentUser: Joi.object().required(),
   job: Joi.object().keys({
+    status: Joi.jobStatus().default('sourcing'),
     projectId: Joi.number().integer().required(),
     externalId: Joi.string(),
     description: Joi.string(),

--- a/src/services/ResourceBookingService.js
+++ b/src/services/ResourceBookingService.js
@@ -105,7 +105,6 @@ async function createResourceBooking (currentUser, resourceBooking) {
   resourceBooking.id = uuid()
   resourceBooking.createdAt = new Date()
   resourceBooking.createdBy = await helper.getUserId(currentUser.userId)
-  resourceBooking.status = 'sourcing'
 
   const created = await ResourceBooking.create(resourceBooking)
   await helper.postEvent(config.TAAS_RESOURCE_BOOKING_CREATE_TOPIC, resourceBooking)
@@ -115,6 +114,7 @@ async function createResourceBooking (currentUser, resourceBooking) {
 createResourceBooking.schema = Joi.object().keys({
   currentUser: Joi.object().required(),
   resourceBooking: Joi.object().keys({
+    status: Joi.jobStatus().default('sourcing'),
     projectId: Joi.number().integer().required(),
     userId: Joi.string().uuid().required(),
     jobId: Joi.string().uuid(),


### PR DESCRIPTION
- Update Joi schemas.
- Update Swagger.
- `ResourceBookingEventHandler` now handles the `taas.resourcebooking.create` event the same way as it handles the `taas.resourcebooking.update` event.