### PR TITLE
remove the clearObject function

### DIFF
--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -541,21 +541,6 @@ function setResHeaders (req, res, result) {
 }
 
 /**
- * Clear the object, remove all null or empty array field
- * @param {Object|Array} obj the given object
- */
-function clearObject (obj) {
-  if (_.isNull(obj)) {
-    return undefined
-  }
-  if (_.isArray(obj)) {
-    return _.map(obj, e => _.omitBy(e, _.isNull))
-  } else {
-    return _.omitBy(obj, (p) => { return _.isNull(p) || (_.isArray(p) && _.isEmpty(p)) })
-  }
-}
-
-/**
  * Get ES Client
  * @return {Object} Elastic Host Client Instance
  */
@@ -1007,7 +992,6 @@ module.exports = {
   checkIfExists,
   autoWrapExpress,
   setResHeaders,
-  clearObject,
   getESClient,
   getUserId: async (userId) => {
     // check m2m user id

--- a/src/services/JobCandidateService.js
+++ b/src/services/JobCandidateService.js
@@ -65,7 +65,7 @@ async function getJobCandidate (currentUser, id, fromDb = false) {
 
   await _checkUserPermissionForGetJobCandidate(currentUser, jobCandidate.jobId) // check user permission
 
-  return helper.clearObject(jobCandidate.dataValues)
+  return jobCandidate.dataValues
 }
 
 getJobCandidate.schema = Joi.object().keys({
@@ -95,7 +95,7 @@ async function createJobCandidate (currentUser, jobCandidate) {
 
   const created = await JobCandidate.create(jobCandidate)
   await helper.postEvent(config.TAAS_JOB_CANDIDATE_CREATE_TOPIC, jobCandidate)
-  return helper.clearObject(created.dataValues)
+  return created.dataValues
 }
 
 createJobCandidate.schema = Joi.object().keys({
@@ -131,7 +131,7 @@ async function updateJobCandidate (currentUser, id, data) {
 
   await jobCandidate.update(data)
   await helper.postEvent(config.TAAS_JOB_CANDIDATE_UPDATE_TOPIC, { id, ...data })
-  const result = helper.clearObject(_.assign(jobCandidate.dataValues, data))
+  const result = _.assign(jobCandidate.dataValues, data)
   return result
 }
 
@@ -289,7 +289,7 @@ async function searchJobCandidates (currentUser, criteria) {
     total: jobCandidates.length,
     page,
     perPage,
-    result: _.map(jobCandidates, jobCandidate => helper.clearObject(jobCandidate.dataValues))
+    result: _.map(jobCandidates, jobCandidate => jobCandidate.dataValues)
   }
 }
 

--- a/src/services/JobService.js
+++ b/src/services/JobService.js
@@ -126,8 +126,8 @@ async function getJob (currentUser, id, fromDb = false) {
 
   await _checkUserPermissionForGetJob(currentUser, job.projectId) // check user permission
 
-  job.dataValues.candidates = _.map(job.dataValues.candidates, (c) => helper.clearObject(c.dataValues))
-  return helper.clearObject(job.dataValues)
+  job.dataValues.candidates = _.map(job.dataValues.candidates, (c) => c.dataValues)
+  return job.dataValues
 }
 
 getJob.schema = Joi.object().keys({
@@ -155,7 +155,7 @@ async function createJob (currentUser, job) {
 
   const created = await Job.create(job)
   await helper.postEvent(config.TAAS_JOB_CREATE_TOPIC, job)
-  return helper.clearObject(created.dataValues)
+  return created.dataValues
 }
 
 createJob.schema = Joi.object().keys({
@@ -205,8 +205,8 @@ async function updateJob (currentUser, id, data) {
   await job.update(data)
   await helper.postEvent(config.TAAS_JOB_UPDATE_TOPIC, { id, ...data }, { oldValue: oldValue })
   job = await Job.findById(id, true)
-  job.dataValues.candidates = _.map(job.dataValues.candidates, (c) => helper.clearObject(c.dataValues))
-  return helper.clearObject(job.dataValues)
+  job.dataValues.candidates = _.map(job.dataValues.candidates, (c) => c.dataValues)
+  return job.dataValues
 }
 
 /**
@@ -466,7 +466,7 @@ async function searchJobs (currentUser, criteria, options = { returnAll: false }
     total: jobs.length,
     page,
     perPage,
-    result: _.map(jobs, job => helper.clearObject(job.dataValues))
+    result: _.map(jobs, job => job.dataValues)
   }
 }
 

--- a/src/services/ResourceBookingService.js
+++ b/src/services/ResourceBookingService.js
@@ -24,9 +24,9 @@ const esClient = helper.getESClient()
  */
 async function _getResourceBookingFilteringFields (currentUser, resourceBooking) {
   if (currentUser.hasManagePermission || currentUser.isMachine) {
-    return helper.clearObject(resourceBooking)
+    return resourceBooking
   }
-  return _.omit(helper.clearObject(resourceBooking), 'memberRate')
+  return _.omit(resourceBooking, 'memberRate')
 }
 
 /**
@@ -108,7 +108,7 @@ async function createResourceBooking (currentUser, resourceBooking) {
 
   const created = await ResourceBooking.create(resourceBooking)
   await helper.postEvent(config.TAAS_RESOURCE_BOOKING_CREATE_TOPIC, resourceBooking)
-  return helper.clearObject(created.dataValues)
+  return created.dataValues
 }
 
 createResourceBooking.schema = Joi.object().keys({
@@ -147,7 +147,7 @@ async function updateResourceBooking (currentUser, id, data) {
 
   await resourceBooking.update(data)
   await helper.postEvent(config.TAAS_RESOURCE_BOOKING_UPDATE_TOPIC, { id, ...data }, { oldValue: oldValue })
-  const result = helper.clearObject(_.assign(resourceBooking.dataValues, data))
+  const result = _.assign(resourceBooking.dataValues, data)
   return result
 }
 
@@ -348,7 +348,7 @@ async function searchResourceBookings (currentUser, criteria, options = { return
     total: resourceBookings.length,
     page,
     perPage,
-    result: _.map(resourceBookings, resourceBooking => helper.clearObject(resourceBooking.dataValues))
+    result: _.map(resourceBookings, resourceBooking => resourceBooking.dataValues)
   }
 }
 


### PR DESCRIPTION
For verification, I tried with the following requests in Postman:

```
create job with booking manager
get job with booking manager
search jobs with booking manager
put job with booking manager
patch job with booking manager

create job candidate with booking manager
get job candidate with booking manager
search job candidates with booking manager
put job candidate with booking manager
patch job candidate with booking manager

create resource booking with booking manager
get resource booking with booking manager
search resource bookings with booking manager
put resource booking with booking manager
patch resource booking with booking manager

GET /taas-teams with booking manager
GET /taas-teams/:id with booking manager (I tried with project id 111)
```

The only difference is all of the responses from the requests for creating records includes new fields `updatedAt` and `updatedBy` and `deletedAt`, with null value:

1. Here is the response from the request `create job with booking manager`:

  ``` bash
  (Notice the response has new fields `updatedAt` and `updatedBy` and `deletedAt`)
  {
      "projectId": 111,
      "externalId": "1212",
      "description": "Dummy Description",
      "startDate": "2020-09-27T04:17:23.131Z",
      "endDate": "2020-09-27T04:17:23.131Z",
      "numPositions": 13,
      "resourceType": "Dummy Resource Type",
      "rateType": "hourly",
      "workload": "full-time",
      "skills": [
          "23e00d92-207a-4b5b-b3c9-4c5662644941",
          "7d076384-ccf6-4e43-a45d-1b24b1e624aa",
          "cbac57a3-7180-4316-8769-73af64893158",
          "a2b4bc11-c641-4a19-9eb7-33980378f82e"
      ],
      "title": "Dummy title - at most 64 characters",
      "status": "sourcing",
      "id": "7ba7f627-b141-4d52-a846-fd2bf3a75c60",
      "createdAt": "2021-02-06T06:01:59.942Z",
      "createdBy": "57646ff9-1cd3-4d3c-88ba-eb09a395366c",
      "updatedAt": null,
      "updatedBy": null,
      "deletedAt": null
  }
  ```

2. Here is the response from the request `create job candidate with booking manager`:

  ``` bash
  (Notice the response has new fields `updatedAt` and `updatedBy` and `deletedAt`)
  {
      "jobId": "7ba7f627-b141-4d52-a846-fd2bf3a75c60",
      "userId": "a55fe1bc-1754-45fa-9adc-cf3d6d7c377a",
      "externalId": "300234321",
      "resume": "http://example.com",
      "status": "open",
      "id": "ae50686a-a296-4ed0-a91a-cf8a1596953d",
      "createdAt": "2021-02-06T06:02:27.443Z",
      "createdBy": "57646ff9-1cd3-4d3c-88ba-eb09a395366c",
      "updatedAt": null,
      "updatedBy": null,
      "deletedAt": null
  }
  ```

3. Here is the response from the request `create resource booking with booking manager`:

  ``` bash
  (Notice the response has new fields `updatedAt` and `updatedBy` and `deletedAt`)
  {
      "projectId": 111,
      "userId": "a55fe1bc-1754-45fa-9adc-cf3d6d7c377a",
      "jobId": "7ba7f627-b141-4d52-a846-fd2bf3a75c60",
      "startDate": "2020-09-27T04:17:23.131Z",
      "endDate": "2020-09-27T04:17:23.131Z",
      "memberRate": 13.23,
      "customerRate": 13,
      "rateType": "hourly",
      "status": "sourcing",
      "id": "dfc04a90-dcc9-4b55-85fb-e2f2afec2199",
      "createdAt": "2021-02-06T06:02:50.999Z",
      "createdBy": "57646ff9-1cd3-4d3c-88ba-eb09a395366c",
      "updatedAt": null,
      "updatedBy": null,
      "deletedAt": null
  }
  ```
