### PR TITLE
Allow null values in request body for optional fields

### DIFF
--- a/src/services/JobCandidateService.js
+++ b/src/services/JobCandidateService.js
@@ -104,8 +104,8 @@ createJobCandidate.schema = Joi.object().keys({
     status: Joi.jobCandidateStatus().default('open'),
     jobId: Joi.string().uuid().required(),
     userId: Joi.string().uuid().required(),
-    externalId: Joi.string(),
-    resume: Joi.string().uri()
+    externalId: Joi.string().allow(null),
+    resume: Joi.string().uri().allow(null)
   }).required()
 }).required()
 
@@ -151,8 +151,8 @@ partiallyUpdateJobCandidate.schema = Joi.object().keys({
   id: Joi.string().uuid().required(),
   data: Joi.object().keys({
     status: Joi.jobCandidateStatus(),
-    externalId: Joi.string(),
-    resume: Joi.string().uri()
+    externalId: Joi.string().allow(null),
+    resume: Joi.string().uri().allow(null)
   }).required()
 }).required()
 
@@ -176,8 +176,8 @@ fullyUpdateJobCandidate.schema = Joi.object().keys({
     jobId: Joi.string().uuid().required(),
     userId: Joi.string().uuid().required(),
     status: Joi.jobCandidateStatus(),
-    externalId: Joi.string(),
-    resume: Joi.string().uri()
+    externalId: Joi.string().allow(null),
+    resume: Joi.string().uri().allow(null)
   }).required()
 }).required()
 

--- a/src/services/JobService.js
+++ b/src/services/JobService.js
@@ -163,15 +163,15 @@ createJob.schema = Joi.object().keys({
   job: Joi.object().keys({
     status: Joi.jobStatus().default('sourcing'),
     projectId: Joi.number().integer().required(),
-    externalId: Joi.string(),
-    description: Joi.stringAllowEmpty(),
+    externalId: Joi.string().allow(null),
+    description: Joi.stringAllowEmpty().allow(null),
     title: Joi.title().required(),
-    startDate: Joi.date(),
-    endDate: Joi.date(),
+    startDate: Joi.date().allow(null),
+    endDate: Joi.date().allow(null),
     numPositions: Joi.number().integer().min(1).required(),
-    resourceType: Joi.stringAllowEmpty(),
-    rateType: Joi.rateType(),
-    workload: Joi.workload(),
+    resourceType: Joi.stringAllowEmpty().allow(null),
+    rateType: Joi.rateType().allow(null),
+    workload: Joi.workload().allow(null),
     skills: Joi.array().items(Joi.string().uuid()).required()
   }).required()
 }).required()
@@ -225,15 +225,15 @@ partiallyUpdateJob.schema = Joi.object().keys({
   id: Joi.string().guid().required(),
   data: Joi.object().keys({
     status: Joi.jobStatus(),
-    externalId: Joi.string(),
-    description: Joi.stringAllowEmpty(),
+    externalId: Joi.string().allow(null),
+    description: Joi.stringAllowEmpty().allow(null),
     title: Joi.title(),
-    startDate: Joi.date(),
-    endDate: Joi.date(),
+    startDate: Joi.date().allow(null),
+    endDate: Joi.date().allow(null),
     numPositions: Joi.number().integer().min(1),
-    resourceType: Joi.stringAllowEmpty(),
-    rateType: Joi.rateType(),
-    workload: Joi.workload(),
+    resourceType: Joi.stringAllowEmpty().allow(null),
+    rateType: Joi.rateType().allow(null),
+    workload: Joi.workload().allow(null),
     skills: Joi.array().items(Joi.string().uuid())
   }).required()
 }).required()
@@ -254,15 +254,15 @@ fullyUpdateJob.schema = Joi.object().keys({
   id: Joi.string().guid().required(),
   data: Joi.object().keys({
     projectId: Joi.number().integer().required(),
-    externalId: Joi.string(),
-    description: Joi.string(),
+    externalId: Joi.string().allow(null),
+    description: Joi.string().allow(null),
     title: Joi.title().required(),
-    startDate: Joi.date(),
-    endDate: Joi.date(),
+    startDate: Joi.date().allow(null),
+    endDate: Joi.date().allow(null),
     numPositions: Joi.number().integer().min(1).required(),
-    resourceType: Joi.string(),
-    rateType: Joi.rateType(),
-    workload: Joi.workload(),
+    resourceType: Joi.string().allow(null),
+    rateType: Joi.rateType().allow(null),
+    workload: Joi.workload().allow(null),
     skills: Joi.array().items(Joi.string().uuid()).required(),
     status: Joi.jobStatus()
   }).required()

--- a/src/services/ResourceBookingService.js
+++ b/src/services/ResourceBookingService.js
@@ -117,11 +117,11 @@ createResourceBooking.schema = Joi.object().keys({
     status: Joi.jobStatus().default('sourcing'),
     projectId: Joi.number().integer().required(),
     userId: Joi.string().uuid().required(),
-    jobId: Joi.string().uuid(),
-    startDate: Joi.date(),
-    endDate: Joi.date(),
-    memberRate: Joi.number(),
-    customerRate: Joi.number(),
+    jobId: Joi.string().uuid().allow(null),
+    startDate: Joi.date().allow(null),
+    endDate: Joi.date().allow(null),
+    memberRate: Joi.number().allow(null),
+    customerRate: Joi.number().allow(null),
     rateType: Joi.rateType().required()
   }).required()
 }).required()
@@ -167,10 +167,10 @@ partiallyUpdateResourceBooking.schema = Joi.object().keys({
   id: Joi.string().uuid().required(),
   data: Joi.object().keys({
     status: Joi.jobStatus(),
-    startDate: Joi.date(),
-    endDate: Joi.date(),
-    memberRate: Joi.number(),
-    customerRate: Joi.number(),
+    startDate: Joi.date().allow(null),
+    endDate: Joi.date().allow(null),
+    memberRate: Joi.number().allow(null),
+    customerRate: Joi.number().allow(null),
     rateType: Joi.rateType()
   }).required()
 }).required()
@@ -196,11 +196,11 @@ fullyUpdateResourceBooking.schema = Joi.object().keys({
   data: Joi.object().keys({
     projectId: Joi.number().integer().required(),
     userId: Joi.string().uuid().required(),
-    jobId: Joi.string().uuid(),
-    startDate: Joi.date(),
-    endDate: Joi.date(),
-    memberRate: Joi.number(),
-    customerRate: Joi.number(),
+    jobId: Joi.string().uuid().allow(null),
+    startDate: Joi.date().allow(null),
+    endDate: Joi.date().allow(null),
+    memberRate: Joi.number().allow(null),
+    customerRate: Joi.number().allow(null),
     rateType: Joi.rateType().required(),
     status: Joi.jobStatus().required()
   }).required()


### PR DESCRIPTION
For POST/PUT/PATCH a job, fields that allow null values are listed below:

- externalId
- description
- startDate
- endDate
- resourceType
- rateType
- workload

For POST/PUT/PATCH a job candidate, fields that allow null values are listed below:

- externalId
- resume

For POST/PUT a resource booking, fields that allow null values are listed below:

- jobId
- startDate
- endDate
- memberRate
- customerRate

For PATCH a resource booking, fields that allow null values are listed below:

  - startDate
  - endDate
  - memberRate
  - customerRate
