### PR TITLE
Add new field `isApplicationPageActive` to the Job model

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -23,6 +23,11 @@ paths:
         Create job.
 
         **Authorization** All topcoder members are allowed
+
+        Permission rules on field `isApplicationPageActive`:
+          - M2M user is allowed to set the value of the field
+          - Other users are not allowed to set the value of the field
+
       security:
         - bearerAuth: []
       requestBody:
@@ -352,6 +357,10 @@ paths:
         Update the job.
 
         **Authorization** Every topcoder member can update the job he/she created. bookingmanager and connectmember can update all jobs.
+
+        Permission rules on field `isApplicationPageActive`:
+          - M2M user is allowed to update the value of the field
+          - Other users are not allowed to update the value of the field
       security:
         - bearerAuth: []
       parameters:
@@ -413,6 +422,10 @@ paths:
         Update job.
 
         **Authorization** Topcoder token with patch job scope is allowed
+
+        Permission rules on field `isApplicationPageActive`:
+          - M2M user is allowed to update the value of the field
+          - Other users are not allowed to update the value of the field
       security:
         - bearerAuth: []
       parameters:
@@ -1980,6 +1993,9 @@ components:
           description: "The job candidates."
           items:
             $ref: '#/components/schemas/JobCandidate'
+        isApplicationPageActive:
+          type: boolean
+          default: false
         createdAt:
           type: string
           format: date-time
@@ -2057,6 +2073,9 @@ components:
             type: string
             format: uuid
             description: "The skill id."
+        isApplicationPageActive:
+          type: boolean
+          default: false
     JobCandidate:
       required: 
         - id
@@ -2186,6 +2205,9 @@ components:
             type: string
             format: uuid
             description: "The skill id."
+        isApplicationPageActive:
+          type: boolean
+          default: false
     ResourceBooking:
       required:
         - id

--- a/migrations/2021-02-27-job-add-is-application-page-active-field.js
+++ b/migrations/2021-02-27-job-add-is-application-page-active-field.js
@@ -1,0 +1,17 @@
+/*
+ * Add isApplicationPageActive field to the Job model.
+ */
+
+module.exports = {
+  up: queryInterface => {
+    return Promise.all([
+      queryInterface.sequelize.query('ALTER TABLE bookings.jobs ADD is_application_page_active BOOLEAN NOT NULL DEFAULT false'),
+      queryInterface.sequelize.query('UPDATE bookings.jobs SET is_application_page_active=false WHERE is_application_page_active is NULL'),
+    ])
+  },
+  down: queryInterface => {
+    return Promise.all([
+      queryInterface.sequelize.query('ALTER TABLE bookings.jobs DROP is_application_page_active')
+    ])
+  }
+}

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -70,6 +70,7 @@ esIndexPropertyMapping[config.get('esConfig.ES_INDEX_JOB')] = {
   workload: { type: 'keyword' },
   skills: { type: 'keyword' },
   status: { type: 'keyword' },
+  isApplicationPageActive: { type: 'boolean' },
   createdAt: { type: 'date' },
   createdBy: { type: 'keyword' },
   updatedAt: { type: 'date' },

--- a/src/models/Job.js
+++ b/src/models/Job.js
@@ -98,6 +98,12 @@ module.exports = (sequelize) => {
         type: Sequelize.STRING(255),
         allowNull: false
       },
+      isApplicationPageActive: {
+        field: 'is_application_page_active',
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+        allowNull: false
+      },
       createdBy: {
         field: 'created_by',
         type: Sequelize.UUID,

--- a/src/services/JobService.js
+++ b/src/services/JobService.js
@@ -148,6 +148,11 @@ async function createJob (currentUser, job) {
     await helper.checkIsMemberOfProject(currentUser.userId, job.projectId)
   }
 
+  // the "isApplicationPageActive" field can be set/updated only by M2M user
+  if (!_.isUndefined(job.isApplicationPageActive) && !currentUser.isMachine) {
+    throw new errors.ForbiddenError('You are not allowed to set/update the value of field "isApplicationPageActive".')
+  }
+
   await _validateSkills(job.skills)
   job.id = uuid()
   job.createdBy = await helper.getUserId(currentUser.userId)
@@ -171,7 +176,8 @@ createJob.schema = Joi.object().keys({
     resourceType: Joi.stringAllowEmpty().allow(null),
     rateType: Joi.rateType().allow(null),
     workload: Joi.workload().allow(null),
-    skills: Joi.array().items(Joi.string().uuid()).required()
+    skills: Joi.array().items(Joi.string().uuid()).required(),
+    isApplicationPageActive: Joi.boolean()
   }).required()
 }).required()
 
@@ -188,6 +194,12 @@ async function updateJob (currentUser, id, data) {
   }
   let job = await Job.findById(id)
   const oldValue = job.toJSON()
+
+  // the "isApplicationPageActive" field can be set/updated only by M2M user
+  if (!_.isUndefined(data.isApplicationPageActive) && !currentUser.isMachine) {
+    throw new errors.ForbiddenError('You are not allowed to set/update the value of field "isApplicationPageActive".')
+  }
+
   const ubahnUserId = await helper.getUserId(currentUser.userId)
   if (!currentUser.hasManagePermission && !currentUser.isMachine) {
     // Check whether user can update the job.
@@ -232,7 +244,8 @@ partiallyUpdateJob.schema = Joi.object().keys({
     resourceType: Joi.stringAllowEmpty().allow(null),
     rateType: Joi.rateType().allow(null),
     workload: Joi.workload().allow(null),
-    skills: Joi.array().items(Joi.string().uuid())
+    skills: Joi.array().items(Joi.string().uuid()),
+    isApplicationPageActive: Joi.boolean()
   }).required()
 }).required()
 
@@ -262,7 +275,8 @@ fullyUpdateJob.schema = Joi.object().keys({
     rateType: Joi.rateType().allow(null).default(null),
     workload: Joi.workload().allow(null).default(null),
     skills: Joi.array().items(Joi.string().uuid()).required(),
-    status: Joi.jobStatus().default('sourcing')
+    status: Joi.jobStatus().default('sourcing'),
+    isApplicationPageActive: Joi.boolean()
   }).required()
 }).required()
 


### PR DESCRIPTION
## Verification
### `isApplicationPageActive` in Job creation
- Set the value of `isApplicationPageActive` by m2m user when creating a job:

    ![success_with_m2m_user](https://imgur.com/e8tUAKO.png)

- Setting the value of `isApplicationPageActive` by adminstrator when creating a job results in 403 error:

    ![403_with_admin](https://imgur.com/tJlsdiL.png)

- Setting the value of `isApplicationPageActive` to `null` when creating a job is forbidden:

    ![null_value_not_allow](https://imgur.com/P3xk09v.png)

### `isApplicationPageActive` in Job updating

- Update the value of `isApplicationPageActive` by m2m user when updating a job:

    ![success_with_m2m_user](https://imgur.com/TIK3Rtc.png)

- Updating the value of `isApplicationPageActive` by adminstrator when updating a job results in 403 error:

    ![403_with_admin](https://imgur.com/7eKfsSN.png)

- Updating the value of `isApplicationPageActive` to `null` when updating a job is forbidden:

    ![null_value_not_allow](https://imgur.com/jxFeWPG.png)
