### PR TITLE
Update MigrationMeta table when running init-db

### DIFF
--- a/src/init-db.js
+++ b/src/init-db.js
@@ -2,15 +2,39 @@
  * Sync the database models to db tables.
  */
 const config = require('config')
+const fs = require('fs')
 const models = require('./models')
 const logger = require('./common/logger')
+
+// the directory at which migration scripts are located
+const MigrationsDirPath = './migrations'
+
+/**
+ * List the filenames of the migration files.
+ *
+ * @returns {Array} the list of filenames
+ */
+function listMigrationFiles () {
+  const filenames = fs.readdirSync(MigrationsDirPath)
+  return filenames
+}
 
 const initDB = async () => {
   if (process.argv[2] === 'force') {
     await models.sequelize.dropSchema(config.DB_SCHEMA_NAME)
   }
   await models.sequelize.createSchema(config.DB_SCHEMA_NAME)
+  // define SequelizeMeta table
+  const SequelizeMeta = await models.sequelize.define('SequelizeMeta', {
+    name: {
+      type: models.Sequelize.STRING(255),
+      allowNull: false
+    }
+  }, { timestamps: false })
+  // re-init all tables including the SequelizeMeta table
   await models.sequelize.sync({ force: true })
+  // add filenames of existing migration scripts to the SequelizeMeta table
+  await SequelizeMeta.bulkCreate(listMigrationFiles().map(filename => ({ name: filename })))
 }
 
 if (!module.parent) {


### PR DESCRIPTION
The PR can be verified by firstly running `npm run init-db` and then running `npm run migrate`, which should output `No migrations were executed, database schema was already up to date.`