### PR TITLE
feat(interview-scheduler): add a limit on max. allowed rounds

### DIFF
--- a/app-constants.js
+++ b/app-constants.js
@@ -66,7 +66,8 @@ const Interviews = {
   XaiTemplate: {
     'interview-30': 30,
     'interview-60': 60
-  }
+  },
+  MaxAllowedCount: 3
 }
 
 const ChallengeStatus = {

--- a/src/services/InterviewService.js
+++ b/src/services/InterviewService.js
@@ -125,6 +125,11 @@ async function requestInterview (currentUser, jobCandidateId, interview) {
   const round = await Interview.count({
     where: { jobCandidateId }
   })
+
+  // throw error if candidate has already had MaxAllowedCount interviews
+  if (round >= InterviewConstants.MaxAllowedCount) {
+    throw new errors.ConflictError(`You've reached the maximum allowed number (${InterviewConstants.MaxAllowedCount}) of interviews for this candidate.`)
+  }
   interview.round = round + 1
 
   try {


### PR DESCRIPTION
Add a limit on maximum allowed number of interview rounds.