### PR TITLE
New action topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,11 @@
    tc-taas-es-processor | 2021-04-09T21:20:21.469Z DEBUG no-kafka-client Subscribed to taas.workperiodpayment.update:0 offset 0 leader kafka:9093
    tc-taas-es-processor | 2021-04-09T21:20:21.470Z DEBUG no-kafka-client Subscribed to taas.workperiodpayment.delete:0 offset 0 leader kafka:9093
    tc-taas-es-processor | 2021-04-09T21:20:21.471Z DEBUG no-kafka-client Subscribed to taas.workperiodpayment.create:0 offset 0 leader kafka:9093
+   tc-taas-es-processor | 2021-04-09T21:20:21.472Z DEBUG no-kafka-client Subscribed to taas.action.retry:0 offset 0 leader kafka:9093
    tc-taas-es-processor | 2021-04-09T21:20:21.473Z DEBUG no-kafka-client Subscribed to taas.job.update:0 offset 0 leader kafka:9093
    tc-taas-es-processor | 2021-04-09T21:20:21.474Z DEBUG no-kafka-client Subscribed to taas.resourcebooking.update:0 offset 0 leader kafka:9093
    tc-taas-es-processor | [2021-04-09T21:20:21.475Z] app INFO : Initialized.......
-   tc-taas-es-processor | [2021-04-09T21:20:21.479Z] app INFO : taas.job.create,taas.job.update,taas.job.delete,taas.jobcandidate.create,taas.jobcandidate.update,taas.jobcandidate.delete,taas.resourcebooking.create,taas.resourcebooking.update,taas.resourcebooking.delete,taas.workperiod.create,taas.workperiod.update,taas.workperiod.delete,taas.workperiodpayment.create,taas.workperiodpayment.update,taas.interview.requested,taas.interview.update,taas.interview.bulkUpdate,taas.role.requested,taas.role.update,taas.role.delete
+   tc-taas-es-processor | [2021-04-09T21:20:21.479Z] app INFO : common.error.reporting,taas.job.create,taas.job.update,taas.job.delete,taas.jobcandidate.create,taas.jobcandidate.update,taas.jobcandidate.delete,taas.resourcebooking.create,taas.resourcebooking.update,taas.resourcebooking.delete,taas.workperiod.create,taas.workperiod.update,taas.workperiod.delete,taas.workperiodpayment.create,taas.workperiodpayment.update,taas.interview.requested,taas.interview.update,taas.interview.bulkUpdate,taas.role.requested,taas.role.update,taas.role.delete,taas.action.retry
    tc-taas-es-processor | [2021-04-09T21:20:21.480Z] app INFO : Kick Start.......
    tc-taas-es-processor | ********** Topcoder Health Check DropIn listening on port 3001
    tc-taas-es-processor | Topcoder Health Check DropIn started and ready to roll

--- a/config/default.js
+++ b/config/default.js
@@ -140,6 +140,8 @@ module.exports = {
   TAAS_ROLE_UPDATE_TOPIC: process.env.TAAS_ROLE_UPDATE_TOPIC || 'taas.role.update',
   // the delete role entity Kafka message topic
   TAAS_ROLE_DELETE_TOPIC: process.env.TAAS_ROLE_DELETE_TOPIC || 'taas.role.delete',
+  // special kafka topics
+  TAAS_ACTION_RETRY_TOPIC: process.env.TAAS_ACTION_RETRY_TOPIC || 'taas.action.retry',
 
   // the Kafka message topic for sending email
   EMAIL_TOPIC: process.env.EMAIL_TOPIC || 'external.action.email',

--- a/local/kafka-client/topics.txt
+++ b/local/kafka-client/topics.txt
@@ -20,3 +20,4 @@ taas.interview.requested
 taas.interview.update
 taas.interview.bulkUpdate
 external.action.email
+taas.action.retry

--- a/test/unit/ResourceBookingService.test.js
+++ b/test/unit/ResourceBookingService.test.js
@@ -447,7 +447,7 @@ describe('resourceBooking service test', () => {
       expect(esClientSearch.calledOnce).to.be.true
       expect(result).to.deep.eq(data.result)
     })
-    it('T25:Search resource bookin from DB', async () => {
+    it('T25:Search resource booking from DB', async () => {
       const data = testData.T25
       const ESClient = commonData.ESClient
       ESClient.search = () => {}
@@ -456,7 +456,7 @@ describe('resourceBooking service test', () => {
         return data.resourceBookingFindAll
       })
       const stubResourceBookingCount = sinon.stub(ResourceBooking, 'count').callsFake(async () => {
-        return data.resourceBookingFindAll.length
+        return data.resourceBookingCount
       })
       const result = await service.searchResourceBookings(commonData.userWithManagePermission, data.criteria)
       expect(esClientSearch.calledOnce).to.be.true

--- a/test/unit/common/ResourceBookingData.js
+++ b/test/unit/common/ResourceBookingData.js
@@ -1229,6 +1229,8 @@ const T25 = {
       updatedAt: '2021-05-08T18:47:37.268Z'
     }
   ],
+  resourceBookingCount: [{ id: 'fbe133dd-0e36-4d0c-8197-49307b13ce75', count: 1 },
+    { id: '60e99790-8da0-4596-badc-29a06feb78a0', count: 1 }],
   criteria: {},
   result: {
     fromDb: true,


### PR DESCRIPTION
Approach - 1
1. Create resourcebooking with dates until taas-es-processor logs produce a 404 error. (usually takes 15-20 creation)
2. After the first retry work period will be created.

Approach - 2
1. Create a resourcebooking
2. Delete the resourcebooking
3. Set deleted_at property to NULL using postgres
4. Create workperiod using that RB's id
5. It will retry until it reaches to max_retry (delays: 1sec, 2sec, 4sec)