### PR TITLE
fix: remove jobIds from query

### DIFF
--- a/src/controllers/JobController.js
+++ b/src/controllers/JobController.js
@@ -61,6 +61,9 @@ async function searchJobs (req, res) {
     req.query.jobIds = req.body.jobIds
   }
   const result = await service.searchJobs(req.authUser, req.query)
+  if (req.query.jobIds) {
+    delete req.query.jobIds
+  }
   helper.setResHeaders(req, res, result)
   res.send(result.result)
 }


### PR DESCRIPTION
After header links for pagination added it returns 502 error if jobIds array has more than ~40 ids.
Especially when all of the first,next and last links are exist.
![Postman 2021-06-06 19 59 05](https://user-images.githubusercontent.com/72204071/120933238-da855d00-c701-11eb-93cb-54b01a88f5ab.png)

when we make page=2, the prev-page link added to the header

![Postman 2021-06-06 19 56 34](https://user-images.githubusercontent.com/72204071/120933261-f4bf3b00-c701-11eb-8f44-57cf4ee032a3.png)
