### PR TITLE
Enriching skills without enrich Elastic.co feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ workflows:
               only:
                 - dev
                 - change-validatations-in-job-jc
+                - feature/enriching-skills-data-with-api-2
 
       # Production builds are exectuted only on tagged commits to the
       # master branch.

--- a/config/default.js
+++ b/config/default.js
@@ -33,10 +33,12 @@ module.exports = {
 
   // the Topcoder v5 url
   TC_API: process.env.TC_API || 'https://api.topcoder-dev.com/v5',
+  // the Topcoder Beta API url currently v5.1
+  TC_BETA_API: process.env.TC_BETA_API || 'https://api.topcoder-dev.com/v5.1',
   // the organization id
   ORG_ID: process.env.ORG_ID || '36ed815b-3da1-49f1-a043-aaed0a4e81ad',
-  // the referenced skill provider id
-  TOPCODER_SKILL_PROVIDER_ID: process.env.TOPCODER_SKILL_PROVIDER_ID || '9cc0795a-6e12-4c84-9744-15858dba1861',
+  // the referenced taxonomy id
+  TOPCODER_TAXONOMY_ID: process.env.TOPCODER_TAXONOMY_ID || '7637ae1a-3b7c-44eb-a5ed-10ea02f1885d',
 
   TOPCODER_USERS_API: process.env.TOPCODER_USERS_API || 'https://api.topcoder-dev.com/v3/users',
   // the api to find topcoder members

--- a/config/default.js
+++ b/config/default.js
@@ -38,7 +38,7 @@ module.exports = {
   // the organization id
   ORG_ID: process.env.ORG_ID || '36ed815b-3da1-49f1-a043-aaed0a4e81ad',
   // the referenced taxonomy id
-  TOPCODER_TAXONOMY_ID: process.env.TOPCODER_TAXONOMY_ID || '7637ae1a-3b7c-44eb-a5ed-10ea02f1885d',
+  TOPCODER_TAXONOMY_ID: process.env.TOPCODER_TAXONOMY_ID || '9cc0795a-6e12-4c84-9744-15858dba1861',
 
   TOPCODER_USERS_API: process.env.TOPCODER_USERS_API || 'https://api.topcoder-dev.com/v3/users',
   // the api to find topcoder members

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3212,7 +3212,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/UbahnSkill"
+                  $ref: "#/components/schemas/SkillInSkillsAPI"
           headers:
             X-Next-Page:
               schema:
@@ -5574,17 +5574,25 @@ components:
           type: string
           example: "React"
           description: The skill name.
-    UbahnSkill:
-      type: object
+    SkillInSkillsAPI:
+      required:
+        - "id"
+        - "name"
+        - "taxonomyId"
+        - "taxonomyName"
+        - "metadata"
       properties:
         id:
           type: "string"
           format: "UUID"
           description: "The skill id"
-        skillProviderId:
+        taxonomyId:
           type: "string"
           format: "UUID"
-          description: "The referenced skill provider id"
+          description: "The referenced taxonomy id"
+        taxonomyName:
+          type: "string"
+          description: "The referenced taxonomy name"
         name:
           type: "string"
           description: "The name of the skill"
@@ -5594,22 +5602,20 @@ components:
         uri:
           type: "string"
           description: "The uri for the skill"
-        created:
-          type: "string"
-          format: "date-time"
-          description: "When the entity was created."
-        updated:
-          type: "string"
-          format: "date-time"
-          description: "When the entity was updated."
-        createdBy:
-          type: "string"
-          format: "UUID"
-          description: "Creator of the entity."
-        updatedBy:
-          type: "string"
-          format: "UUID"
-          description: "User that last updated the entity."
+        metadata:
+          type: "object"
+          description: "The metadata for the skill"
+          properties:
+            updated:
+              type: "string"
+              format: "date-time"
+              description: "The last updated timestamp of the skill"
+            challengeProminence:
+              type: "string"
+              description: "The challenge prominence ranging from [0, 1]"
+            memberProminence:
+              type: "string"
+              description: "The member prominence ranging from [0, 1]"
     JobForTeam:
       properties:
         id:

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -951,6 +951,7 @@ async function listUsersByExternalId (externalId) {
     context: 'listUserByExternalId',
     message: `response body: ${JSON.stringify(res.body)}`
   })
+
   return res.body
 }
 
@@ -1093,9 +1094,7 @@ async function getUserById (userId, enrich) {
   const user = _.pick(res.body, ['id', 'handle', 'firstName', 'lastName'])
 
   if (enrich) {
-    user.skills = (res.body.skills || []).map((skillObj) =>
-      _.pick(skillObj.skill, ['id', 'name'])
-    )
+    user.skills = await Promise.all((res.body.skills || []).map(async (userSkill) => getSkillById(userSkill.skillId)))
     const attributes = _.get(res, 'body.attributes', [])
     user.attributes = _.map(attributes, (attr) =>
       _.pick(attr, ['id', 'value', 'attribute.id', 'attribute.name'])
@@ -1212,7 +1211,7 @@ async function getProjectById (currentUser, id) {
 
 /**
  * Function to search skills from v5/skills
- * - only returns skills from Topcoder Skills Provider defined by `TOPCODER_SKILL_PROVIDER_ID`
+ * - only returns skills from Topcoder Skills API defined by `TOPCODER_TAXONOMY_ID`
  *
  * @param {Object} criteria the search criteria
  * @returns the request result
@@ -1221,9 +1220,9 @@ async function getTopcoderSkills (criteria) {
   const token = await getM2MUbahnToken()
   try {
     const res = await request
-      .get(`${config.TC_API}/skills`)
+      .get(`${config.TC_BETA_API}/skills`)
       .query({
-        skillProviderId: config.TOPCODER_SKILL_PROVIDER_ID,
+        taxonomyId: config.TOPCODER_TAXONOMY_ID,
         ...criteria
       })
       .set('Authorization', `Bearer ${token}`)
@@ -1249,7 +1248,7 @@ async function getTopcoderSkills (criteria) {
 
 /**
  * Function to search and retrive all skills from v5/skills
- * - only returns skills from Topcoder Skills Provider defined by `TOPCODER_SKILL_PROVIDER_ID`
+ * - only returns skills from Topcoder Skills API defined by `TOPCODER_TAXONOMY_ID`
  *
  * @param {Object} criteria the search criteria
  * @returns the request result
@@ -1273,7 +1272,7 @@ async function getAllTopcoderSkills (criteria) {
 async function getSkillById (skillId) {
   const token = await getM2MUbahnToken()
   const res = await request
-    .get(`${config.TC_API}/skills/${skillId}`)
+    .get(`${config.TC_BETA_API}/skills/${skillId}`)
     .set('Authorization', `Bearer ${token}`)
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json')


### PR DESCRIPTION
This PR allows the taas-apis to pull skills details from skills api instead of pulling it from skills ES index which was using the elastic.co's `enrich` feature.