### PR TITLE
Update the way how we generate Zoom links:

### DIFF
--- a/app-constants.js
+++ b/app-constants.js
@@ -192,6 +192,11 @@ const SearchUsers = {
 // provider which we have to enforce for Nylas Virtual Calendars
 const NylasVirtualCalendarProvider = 'nylas'
 
+const ZoomLinkType = {
+  HOST: 'host',
+  GUEST: 'guest'
+}
+
 module.exports = {
   UserRoles,
   FullManagePermissionRoles,
@@ -209,5 +214,6 @@ module.exports = {
   JobStatus,
   JobCandidateStatus,
   SearchUsers,
-  NylasVirtualCalendarProvider
+  NylasVirtualCalendarProvider,
+  ZoomLinkType
 }

--- a/config/default.js
+++ b/config/default.js
@@ -187,6 +187,8 @@ module.exports = {
   TAAS_APP_BFF_BASE_URL: process.env.TAAS_APP_BFF_BASE_URL || 'https://platform.topcoder-dev.com/taas-app',
   // the URL where TaaS App Earn is hosted
   TAAS_APP_EARN_URL: process.env.TAAS_APP_EARN_URL || 'https://platform.topcoder-dev.com/earn/my-gigs',
+  // the URL where TaaS API is hosted
+  TAAS_API_BASE_URL: process.env.TAAS_API_BASE_URL || 'http://localhost:3000/api/v5',
   // environment variables for Payment Service
   ROLE_ID_SUBMITTER: process.env.ROLE_ID_SUBMITTER || '732339e7-8e30-49d7-9198-cccf9451e221',
   TYPE_ID_TASK: process.env.TYPE_ID_TASK || 'ecd58c69-238f-43a4-a4bb-d172719b9f31',
@@ -356,5 +358,10 @@ module.exports = {
   NYLAS_CONNECT_CALENDAR_JWT_SECRET: process.env.NYLAS_CONNECT_CALENDAR_JWT_SECRET || 'secret',
 
   // Zoom JWT credentials
-  ZOOM_ACCOUNTS: process.env.ZOOM_ACCOUNTS
+  ZOOM_ACCOUNTS: process.env.ZOOM_ACCOUNTS,
+
+  // The secret key for get zoom link token
+  ZOOM_LINK_SECRET: process.env.ZOOM_LINK_SECRET || 'zoom-link-secret',
+  // The get zoom link token expiry time
+  ZOOM_LINK_TOKEN_EXPIRY: process.env.ZOOM_LINK_TOKEN_EXPIRY || '180d'
 }

--- a/docs/Topcoder-bookings-api.postman_collection.json
+++ b/docs/Topcoder-bookings-api.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "9a2573b4-16c9-4073-bd4f-51d0934cec11",
+		"_postman_id": "db078688-3b62-457d-8f7a-c680a6ef3d42",
 		"name": "Topcoder-bookings-api",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -7730,6 +7730,170 @@
 								"jobCandidates",
 								"{{jobCandidateId}}",
 								"interviews"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get zoom-link without token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test('Status code is 400', function () {\r",
+									"    pm.response.to.have.status(400);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{URL}}/getInterview/{{interviewId}}/zoom-link?type=host",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"getInterview",
+								"{{interviewId}}",
+								"zoom-link"
+							],
+							"query": [
+								{
+									"key": "type",
+									"value": "host"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get host zoom-link by guest token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test('Status code is 400', function () {\r",
+									"    pm.response.to.have.status(400);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{URL}}/getInterview/{{interviewId}}/zoom-link?type=host&token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0eXBlIjoiZ3Vlc3QiLCJpZCI6IjBkNWI1Y2MzLWQ1NjQtNDlhZC05ZGRmLWM5Zjc5MjRjYjY4NSIsImlhdCI6MTYzNzg5MDIzMSwiZXhwIjoxNjUzNDQyMjMxfQ.S54nYJ5FG4eF1OCFzQ44IGOdeyp30duZrA0APG1xOqg",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"getInterview",
+								"{{interviewId}}",
+								"zoom-link"
+							],
+							"query": [
+								{
+									"key": "type",
+									"value": "host"
+								},
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0eXBlIjoiZ3Vlc3QiLCJpZCI6IjBkNWI1Y2MzLWQ1NjQtNDlhZC05ZGRmLWM5Zjc5MjRjYjY4NSIsImlhdCI6MTYzNzg5MDIzMSwiZXhwIjoxNjUzNDQyMjMxfQ.S54nYJ5FG4eF1OCFzQ44IGOdeyp30duZrA0APG1xOqg"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get guest zoom-link by host toke",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test('Status code is 400', function () {\r",
+									"    pm.response.to.have.status(400);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{URL}}/getInterview/{{interviewId}}/zoom-link?type=guest&token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0eXBlIjoiaG9zdCIsImlkIjoiMGQ1YjVjYzMtZDU2NC00OWFkLTlkZGYtYzlmNzkyNGNiNjg1IiwiaWF0IjoxNjM3ODkwMjMxLCJleHAiOjE2NTM0NDIyMzF9.cR6DCYvakmKrJGpbvSyvvhk_hs_jzhRZGGPwU-9cFY0",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"getInterview",
+								"{{interviewId}}",
+								"zoom-link"
+							],
+							"query": [
+								{
+									"key": "type",
+									"value": "guest"
+								},
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0eXBlIjoiaG9zdCIsImlkIjoiMGQ1YjVjYzMtZDU2NC00OWFkLTlkZGYtYzlmNzkyNGNiNjg1IiwiaWF0IjoxNjM3ODkwMjMxLCJleHAiOjE2NTM0NDIyMzF9.cR6DCYvakmKrJGpbvSyvvhk_hs_jzhRZGGPwU-9cFY0"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get zoom-link by invalid token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test('Status code is 401', function () {\r",
+									"    pm.response.to.have.status(401);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{URL}}/getInterview/{{interviewId}}/zoom-link?type=host&token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0eXBlIjoiaG9zdCIsImlkIjoiMGQ1YjVjYzMtZDU2NC00OWFkLTlkZGYtYzlmNzkyNGNiNjg1IiwiaWF0IjoxNjM3ODkwMjMxLCJleHAiOjE2NTM0NDIyMzF9.cR6DCYvakmKrJGpbvSyvvhk_hs_jzhRZGGPwU-9cFY0dae",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"getInterview",
+								"{{interviewId}}",
+								"zoom-link"
+							],
+							"query": [
+								{
+									"key": "type",
+									"value": "host"
+								},
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0eXBlIjoiaG9zdCIsImlkIjoiMGQ1YjVjYzMtZDU2NC00OWFkLTlkZGYtYzlmNzkyNGNiNjg1IiwiaWF0IjoxNjM3ODkwMjMxLCJleHAiOjE2NTM0NDIyMzF9.cR6DCYvakmKrJGpbvSyvvhk_hs_jzhRZGGPwU-9cFY0dae"
+								}
 							]
 						}
 					},

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1108,7 +1108,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UpdateInterviewRequestBody"
+              $ref: "#/components/schemas/UpdateInterviewByRequestBody"
       responses:
         "200":
           description: OK
@@ -1167,7 +1167,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UpdateInterviewRequestBody"
+              $ref: "#/components/schemas/UpdateInterviewByRequestBody"
       responses:
         "200":
           description: OK
@@ -1423,6 +1423,69 @@ paths:
                 $ref: "#/components/schemas/Error"
         "403":
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /getInterview/{id}/zoom-link:
+    get:
+      tags:
+        - Interviews
+      description: |
+        Get a fresh Zoom Links from Zoom Meeting and redirect to Zoom Link.
+
+      parameters:
+        - in: path
+          name: id
+          description: The interview or xai id.
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: type
+          description: the zoom link type (host or guest).
+          required: true
+          schema:
+            type: string
+            enum:
+              - host
+              - guest
+        - in: query
+          name: token
+          description: the request token.
+          required: true
+          schema:
+            type: string
+      responses:
+        "302":
+          description: Redirect to link of Zoom Meeting
+          headers:
+            Location:
+              description: Zoom Meeting Link.
+              schema:
+                type: string
+                format: uri
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Not authenticated
           content:
             application/json:
               schema:
@@ -3126,7 +3189,8 @@ paths:
           description: The userId
           required: true
           schema:
-            type: uuid
+            type: string
+            format: uuid
 
       responses:
         "200":
@@ -3182,7 +3246,8 @@ paths:
           description: The UUID of the User whose calendar should be deleted
           required: true
           schema:
-            type: uuid
+            type: string
+            format: uuid
         - in: path
           name: calendarId
           description: The id of the calendar to delete. This id comes from Nylas backend server
@@ -3806,6 +3871,12 @@ paths:
         - Teams
       description: |
         Returns suggested members for the given handle fragment
+      parameters:
+        - in: path
+          name: fragment
+          required: true
+          schema:
+            type: string
       security:
         - bearerAuth: []
       responses:

--- a/migrations/2021-11-25-add-interview-zoom-fields.js
+++ b/migrations/2021-11-25-add-interview-zoom-fields.js
@@ -1,0 +1,32 @@
+'use strict';
+const config = require('config')
+
+/*
+ * Add zoomAccountApiKey, zoomMeetingId to the Interview model.
+ */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const interviewsTable = { tableName: 'interviews', schema: config.DB_SCHEMA_NAME }
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      await queryInterface.addColumn(interviewsTable, 'zoom_account_api_key', { type: Sequelize.STRING(255), allowNull: true }, { transaction })
+      await queryInterface.addColumn(interviewsTable, 'zoom_meeting_id', { type: Sequelize.BIGINT, allowNull: true }, { transaction })
+      await transaction.commit()
+    } catch (err) {
+      await transaction.rollback()
+      throw err
+    }
+  },
+  down: async (queryInterface, Sequelize) => {
+    const interviewsTable = { tableName: 'interviews', schema: config.DB_SCHEMA_NAME }
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      await queryInterface.removeColumn(interviewsTable, 'zoom_account_api_key', { transaction })
+      await queryInterface.removeColumn(interviewsTable, 'zoom_meeting_id', { transaction })
+      await transaction.commit()
+    } catch (err) {
+      await transaction.rollback()
+      throw err
+    }
+  }
+};

--- a/src/controllers/InterviewController.js
+++ b/src/controllers/InterviewController.js
@@ -71,6 +71,16 @@ async function searchInterviews (req, res) {
   res.send(result.result)
 }
 
+/**
+ * Get a fresh Zoom Links from Zoom Meeting and redirect to Zoom Link
+ * @param req the request
+ * @param res the response
+ */
+async function getZoomLink (req, res) {
+  const zoomLink = await service.getZoomLink(req.params.id, req.query)
+  return res.redirect(zoomLink)
+}
+
 module.exports = {
   getInterviewByRound,
   getInterviewById,
@@ -78,5 +88,6 @@ module.exports = {
   partiallyUpdateInterviewByRound,
   partiallyUpdateInterviewById,
   searchInterviews,
-  partiallyUpdateInterviewByWebhook
+  partiallyUpdateInterviewByWebhook,
+  getZoomLink
 }

--- a/src/eventHandlers/InterviewEventHandler.js
+++ b/src/eventHandlers/InterviewEventHandler.js
@@ -12,7 +12,7 @@ const helper = require('../common/helper')
 const Constants = require('../../app-constants')
 const notificationsSchedulerService = require('../services/NotificationsSchedulerService')
 const Interview = models.Interview
-const { generateZoomMeetingLink } = require('../services/ZoomService')
+const { generateZoomMeetingLink, updateZoomMeeting, cancelZoomMeeting } = require('../services/ZoomService')
 /**
  * Send interview invitaion notifications
  * @param {*} interview the requested interview
@@ -127,10 +127,18 @@ async function sendInterviewScheduledNotifications (payload) {
     const data = await notificationsSchedulerService.getDataForInterview(interviewEntity)
     if (!data) { return }
 
-    const links = await generateZoomMeetingLink()
+    const { meeting, zoomAccountApiKey } = await generateZoomMeetingLink(interviewEntity.startTimestamp, interviewEntity.duration)
+
+    await interviewEntity.update({ zoomAccountApiKey, zoomMeetingId: meeting.id })
 
     const interviewCancelLink = `${config.TAAS_APP_BASE_URL}/interview/${interview.id}/cancel`
     const interviewRescheduleLink = `${config.TAAS_APP_BASE_URL}/interview/${interview.id}/reschedule`
+
+    const hostZoomToken = helper.signZoomLink({ type: Constants.ZoomLinkType.HOST, id: interview.id })
+    const hostZoomLink = `${config.TAAS_API_BASE_URL}/getInterview/${interview.id}/zoom-link?type=${Constants.ZoomLinkType.HOST}&token=${hostZoomToken}`
+
+    const guestZoomToken = helper.signZoomLink({ type: Constants.ZoomLinkType.GUEST, id: interview.id })
+    const guestZoomLink = `${config.TAAS_API_BASE_URL}/getInterview/${interview.id}/zoom-link?type=${Constants.ZoomLinkType.GUEST}&token=${guestZoomToken}`
 
     await notificationsSchedulerService.sendNotification({}, {
       template,
@@ -139,7 +147,7 @@ async function sendInterviewScheduledNotifications (payload) {
         host: data.hostFullName,
         guest: data.guestFullName,
         jobTitle: data.jobTitle,
-        zoomLink: links.start_url,
+        zoomLink: hostZoomLink,
         start: moment(interview.startTimestamp).tz(interviewEntity.hostTimezone).format(TIME_FORMAT) + ` ${interviewEntity.hostTimezone}`,
         end: moment(interview.endTimestamp).tz(interviewEntity.hostTimezone).format(TIME_FORMAT) + ` ${interviewEntity.hostTimezone}`,
         hostTimezone: interviewEntity.hostTimezone,
@@ -160,7 +168,7 @@ async function sendInterviewScheduledNotifications (payload) {
           host: data.hostFullName,
           guest: data.guestFullName,
           jobTitle: data.jobTitle,
-          zoomLink: links.join_url,
+          zoomLink: guestZoomLink,
           start: moment(interview.startTimestamp).tz(guestTimezone).format(TIME_FORMAT) + ` ${guestTimezone}`,
           end: moment(interview.endTimestamp).tz(guestTimezone).format(TIME_FORMAT) + ` ${guestTimezone}`,
           guestTimezone,
@@ -249,10 +257,16 @@ async function sendInterviewRescheduledNotifications (payload) {
     const data = await notificationsSchedulerService.getDataForInterview(interviewEntity)
     if (!data) { return }
 
-    const links = await generateZoomMeetingLink()
+    await updateZoomMeeting(interviewEntity.startTimestamp, interviewEntity.duration, interviewEntity.zoomAccountApiKey, interviewEntity.zoomMeetingId)
 
     const interviewCancelLink = `${config.TAAS_APP_BASE_URL}/interview/${interview.id}/cancel`
     const interviewRescheduleLink = `${config.TAAS_APP_BASE_URL}/interview/${interview.id}/reschedule`
+
+    const hostZoomToken = helper.signZoomLink({ type: Constants.ZoomLinkType.HOST, id: interview.id })
+    const hostZoomLink = `${config.TAAS_API_BASE_URL}/getInterview/${interview.id}/zoom-link?type=${Constants.ZoomLinkType.HOST}&token=${hostZoomToken}`
+
+    const guestZoomToken = helper.signZoomLink({ type: Constants.ZoomLinkType.GUEST, id: interview.id })
+    const guestZoomLink = `${config.TAAS_API_BASE_URL}/getInterview/${interview.id}/zoom-link?type=${Constants.ZoomLinkType.GUEST}&token=${guestZoomToken}`
 
     await notificationsSchedulerService.sendNotification({}, {
       template,
@@ -261,7 +275,7 @@ async function sendInterviewRescheduledNotifications (payload) {
         host: data.hostFullName,
         guest: data.guestFullName,
         jobTitle: data.jobTitle,
-        zoomLink: links.start_url,
+        zoomLink: hostZoomLink,
         oldStart: moment(interviewOldValue.startTimestamp).tz(interviewEntity.hostTimezone).format(TIME_FORMAT) + ` ${interviewEntity.hostTimezone}`,
         start: moment(interview.startTimestamp).tz(interviewEntity.hostTimezone).format(TIME_FORMAT) + ` ${interviewEntity.hostTimezone}`,
         end: moment(interview.endTimestamp).tz(interviewEntity.hostTimezone).format(TIME_FORMAT) + ` ${interviewEntity.hostTimezone}`,
@@ -283,7 +297,7 @@ async function sendInterviewRescheduledNotifications (payload) {
           host: data.hostFullName,
           guest: data.guestFullName,
           jobTitle: data.jobTitle,
-          zoomLink: links.join_url,
+          zoomLink: guestZoomLink,
           oldStart: moment(interviewOldValue.startTimestamp).tz(guestTimezone).format(TIME_FORMAT) + ` ${guestTimezone}`,
           start: moment(interview.startTimestamp).tz(guestTimezone).format(TIME_FORMAT) + ` ${guestTimezone}`,
           end: moment(interview.endTimestamp).tz(guestTimezone).format(TIME_FORMAT) + ` ${guestTimezone}`,
@@ -361,6 +375,8 @@ async function sendInterviewCancelledNotifications (payload) {
     // send host email
     const data = await notificationsSchedulerService.getDataForInterview(interviewEntity)
     if (!data) { return }
+
+    await cancelZoomMeeting(interviewEntity.zoomAccountApiKey, interviewEntity.zoomMeetingId)
 
     await notificationsSchedulerService.sendNotification({}, {
       template,

--- a/src/models/Interview.js
+++ b/src/models/Interview.js
@@ -112,6 +112,16 @@ module.exports = (sequelize) => {
         field: 'end_timestamp',
         type: Sequelize.DATE
       },
+      zoomAccountApiKey: {
+        field: 'zoom_account_api_key',
+        type: Sequelize.STRING(255),
+        allowNull: true
+      },
+      zoomMeetingId: {
+        field: 'zoom_meeting_id',
+        type: Sequelize.BIGINT,
+        allowNull: true
+      },
       status: {
         type: Sequelize.ENUM(statuses),
         allowNull: false

--- a/src/routes/InterviewRoutes.js
+++ b/src/routes/InterviewRoutes.js
@@ -57,5 +57,11 @@ module.exports = {
       auth: 'jwt',
       scopes: [constants.Scopes.READ_INTERVIEW, constants.Scopes.ALL_INTERVIEW]
     }
+  },
+  '/getInterview/:id/zoom-link': {
+    get: {
+      controller: 'InterviewController',
+      method: 'getZoomLink'
+    }
   }
 }

--- a/src/services/InterviewService.js
+++ b/src/services/InterviewService.js
@@ -9,7 +9,7 @@ const config = require('config')
 const { Op, ForeignKeyConstraintError } = require('sequelize')
 const { v4: uuid } = require('uuid')
 const { createHash } = require('crypto')
-const { Interviews: InterviewConstants } = require('../../app-constants')
+const { Interviews: InterviewConstants, ZoomLinkType } = require('../../app-constants')
 const helper = require('../common/helper')
 const logger = require('../common/logger')
 const errors = require('../common/errors')
@@ -37,6 +37,7 @@ const {
 } = require('./NylasService')
 const { syncUserMeetingsSettings } = require('./UserMeetingSettingsService')
 const { processInterviewWebhookUsingMutex } = require('../common/helper')
+const { getZoomMeeting } = require('./ZoomService')
 
 // Each request made by Nylas in the partiallyUpdateInterviewByWebhook endpoint
 // includes a SHA256 hash of a secret (stored in env variable) to be sent in the
@@ -856,6 +857,35 @@ partiallyUpdateInterviewByWebhook.schema = Joi.object().keys({
   webhookBody: Joi.object().invalid({}).required()
 }).required()
 
+/**
+ * Get zoom link.
+ *
+ * @param {String} interviewId the interview id
+ * @param {Object} data the request query data
+ * @returns zoom link
+ */
+async function getZoomLink (interviewId, data) {
+  const { type, id } = helper.verifyZoomLinkToken(data.token)
+  if (data.type !== type || interviewId !== id) {
+    throw new errors.BadRequestError('Invalid type or id.')
+  }
+  const interview = await Interview.findById(interviewId)
+  const zoomMeeting = await getZoomMeeting(interview.zoomAccountApiKey, interview.zoomMeetingId)
+  if (data.type === ZoomLinkType.HOST) {
+    return zoomMeeting.start_url
+  } else if (data.type === ZoomLinkType.GUEST) {
+    return zoomMeeting.join_url
+  }
+}
+
+getZoomLink.schema = Joi.object().keys({
+  interviewId: Joi.string().uuid().required(),
+  data: Joi.object().keys({
+    type: Joi.string().valid(ZoomLinkType.HOST, ZoomLinkType.GUEST).required(),
+    token: Joi.string().required()
+  }).required()
+}).required()
+
 module.exports = {
   getInterviewByRound,
   getInterviewById,
@@ -864,5 +894,6 @@ module.exports = {
   partiallyUpdateInterviewById,
   searchInterviews,
   updateCompletedInterviews,
-  partiallyUpdateInterviewByWebhook
+  partiallyUpdateInterviewByWebhook,
+  getZoomLink
 }


### PR DESCRIPTION
  - create Zoom Meeting with time and duration defined, and update it if we update it for the interview
  - instead of directly sending short-lasting zoom links, send long-lasting Topcoder API links which always obtain fresh Zoom links and redirect