### PR TITLE
Update fix: use _.tostring instead of global tostring

### DIFF
--- a/scripts/process-remaining-ubahn-uuids.js
+++ b/scripts/process-remaining-ubahn-uuids.js
@@ -55,7 +55,7 @@ const processRemainingUUIDs = async (tableName, columnNames) => {
       let results = await models.sequelize.query(query, { type: Sequelize.QueryTypes.SELECT })
 
       if (results.length > 0) {
-        results = _.uniq(_.map(_.filter(results, val => toString(val[`${columnName}`]).length > 9), val => val[`${columnName}`]))
+        results = _.uniq(_.map(_.filter(results, val => _.toString(val[`${columnName}`]).length > 9), val => val[`${columnName}`]))
         console.log(`SQL query result: ${JSON.stringify(results)}`)
 
         // get the ubahn uuid to handle map


### PR DESCRIPTION
In `scripts/process-remaining-ubahn-uuids.js`, calling `toString(val[columnName])` incorrectly resolves to `global.toString` in Node.js, which evaluates to `"[object global]"` (always greater than length 9). This has been corrected to use lodash's `_.toString` to ensure the column value is properly converted to a string representation.

$ https://github.com/topcoder-archive/taas-apis/issues/592
Fixes https://github.com/topcoder-archive/taas-apis/issues/592