### PR TITLE
Update fix tcuserid resolution mapping, handling of empty ar

### DIFF
--- a/scripts/common/tcUserId.js
+++ b/scripts/common/tcUserId.js
@@ -4,12 +4,14 @@ const helper = require('../../src/common/helper')
 
 let handleToUserIdMap
 
-if (process.env.NODE_ENV === 'development') {
+const env = process.env.NODE_ENV || 'development'
+
+if (env === 'development' || env === 'test') {
   handleToUserIdMap = require('../data/dev/dev_handle_to_userId.map.json')
-} else if (process.env.NODE_ENV === 'production') {
+} else if (env === 'production') {
   handleToUserIdMap = require('../data/prod/prod_handle_to_userId.map.json')
 } else {
-  console.log('NODE_ENV should be one of \'development\' or \'production\' - Exiting!!')
+  console.log('NODE_ENV should be one of \'development\', \'test\' or \'production\' - Exiting!!')
   process.exit(1)
 }
 
@@ -26,6 +28,10 @@ if (process.env.NODE_ENV === 'development') {
 const getUserUbahnUUIDToHandleMap = async (connection, uniqueUUIDs) => {
   // make sure we are working with unique array of UUIDs
   const _uniqueUUIDs = _.compact(_.uniq(uniqueUUIDs))
+
+  if (_uniqueUUIDs.length === 0) {
+    return {}
+  }
 
   const commaSeparatedUbahnUUIDs = _.join(_.map(_uniqueUUIDs, u => `'${u}'`), ',')
 
@@ -49,7 +55,7 @@ const getUbahnDatabaseConnection = async (url) => {
 }
 
 const getTcUserIdByHandle = async (handle) => {
-  let tcCreatedById = handleToUserIdMap[handle]
+  let tcCreatedById = handleToUserIdMap[handle] || handleToUserIdMap[handle.toLowerCase()]
 
   if (_.isUndefined(tcCreatedById)) {
     console.log(`Could not find mapping for TC handle ${handle} to TC user id in the mapping file. Trying to get it from member-api...`)
@@ -61,6 +67,7 @@ const getTcUserIdByHandle = async (handle) => {
       tcCreatedById = memberDetails.userId
       console.log(`Got tc user id ${tcCreatedById} for handle ${handle} from member-api. Adding it to the mapping in memory...`)
       handleToUserIdMap[handle] = tcCreatedById
+      handleToUserIdMap[handle.toLowerCase()] = tcCreatedById
     }
   }
 

--- a/scripts/process-remaining-ubahn-uuids.js
+++ b/scripts/process-remaining-ubahn-uuids.js
@@ -55,7 +55,7 @@ const processRemainingUUIDs = async (tableName, columnNames) => {
       let results = await models.sequelize.query(query, { type: Sequelize.QueryTypes.SELECT })
 
       if (results.length > 0) {
-        results = _.uniq(_.map(_.filter(results, val => toString(val[`${columnName}`]).length > 9), val => val[`${columnName}`]))
+        results = _.uniq(_.map(_.filter(results, val => _.toString(val[`${columnName}`]).length > 9), val => val[`${columnName}`]))
         console.log(`SQL query result: ${JSON.stringify(results)}`)
 
         // get the ubahn uuid to handle map

--- a/scripts/process-remaining-ubahn-uuids.js
+++ b/scripts/process-remaining-ubahn-uuids.js
@@ -65,17 +65,19 @@ const processRemainingUUIDs = async (tableName, columnNames) => {
         // get the handle to legacy topcoder id map
         for (const handle of Object.values(uuidToHandleMap)) {
           console.log(`handle to search for ${handle}`)
-          if (_.isUndefined(handleToIDMap[handle])) {
+          const handleLower = handle.toLowerCase()
+          if (_.isUndefined(handleToIDMap[handleLower])) {
             const member = await getMemberDetailsByHandle(handle)
-            handleToIDMap[member.handleLower] = member.userId
+            handleToIDMap[handleLower] = (member && member.userId) || null
           }
         }
 
         // build the update queries
         let sql = ''
         for (const [key, value] of Object.entries(uuidToHandleMap)) {
-          if (!_.isUndefined(handleToIDMap[value.toLowerCase()])) {
-            sql += `UPDATE bookings.${tableName} SET ${columnName} = '${handleToIDMap[value.toLowerCase()]}' WHERE ${columnName} = '${key}';`
+          const matchedUserId = handleToIDMap[value.toLowerCase()]
+          if (matchedUserId) {
+            sql += `UPDATE bookings.${tableName} SET ${columnName} = '${matchedUserId}' WHERE ${columnName} = '${key}';`
           }
         }
 


### PR DESCRIPTION
Fixed three major issues in the migration scripts: (1) Added fallback to 'development' environment if NODE_ENV is unset/test in tcUserId.js to prevent immediate exits; (2) Added a safeguard in getUserUbahnUUIDToHandleMap to prevent SQL syntax errors when an empty array of user IDs is queried; (3) Standardized handle lookups to be case-insensitive to avoid repetitive lookup API calls and potential crashes.

$ https://github.com/topcoder-archive/taas-apis/issues/623
Fixes https://github.com/topcoder-archive/taas-apis/issues/623